### PR TITLE
fix: depend on stable versions of packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kilohealth",
+  "name": "@kilohealth/eslint-config",
   "private": true,
   "keywords": [
     "react-native",

--- a/packages/eslint-config-next/CHANGELOG.md
+++ b/packages/eslint-config-next/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [@kilohealth/eslint-config-next-v1.0.1-beta.1](https://github.com/kilohealth/eslint-config/compare/@kilohealth/eslint-config-next-v1.0.0...@kilohealth/eslint-config-next-v1.0.1-beta.1) (2023-01-25)
+
+
+### Bug Fixes
+
+* depend on stable versions of packages ([b3b0a5e](https://github.com/kilohealth/eslint-config/commit/b3b0a5ef732ca06769660ff92cefcea57d15040a))
+
 ## @kilohealth/eslint-config-next-v1.0.0 (2023-01-25)
 
 

--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -14,8 +14,8 @@
   "author": "Kilo.Health",
   "main": "./index.js",
   "dependencies": {
-    "@kilohealth/eslint-config-react": "^1.0.0-beta.1",
-    "@next/eslint-plugin-next": "^13.1.4"
+    "@kilohealth/eslint-config-react": "^1.0.0",
+    "@next/eslint-plugin-next": "^13.1.5"
   },
   "peerDependencies": {
     "eslint": "^8.3.0"

--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilohealth/eslint-config-next",
-  "version": "1.0.0",
+  "version": "1.0.1-beta.1",
   "description": "Kilo.Health ESLint config for Next.js",
   "keywords": [
     "eslint",

--- a/packages/eslint-config-react-native/CHANGELOG.md
+++ b/packages/eslint-config-react-native/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [@kilohealth/eslint-config-react-native-v1.0.1-beta.1](https://github.com/kilohealth/eslint-config/compare/@kilohealth/eslint-config-react-native-v1.0.0...@kilohealth/eslint-config-react-native-v1.0.1-beta.1) (2023-01-25)
+
+
+### Bug Fixes
+
+* depend on stable versions of packages ([b3b0a5e](https://github.com/kilohealth/eslint-config/commit/b3b0a5ef732ca06769660ff92cefcea57d15040a))
+
 ## @kilohealth/eslint-config-react-native-v1.0.0 (2023-01-25)
 
 

--- a/packages/eslint-config-react-native/package.json
+++ b/packages/eslint-config-react-native/package.json
@@ -14,7 +14,7 @@
   "author": "Kilo.Health",
   "main": "./index.js",
   "dependencies": {
-    "@kilohealth/eslint-config-react": "^1.0.0-beta.1",
+    "@kilohealth/eslint-config-react": "^1.0.0",
     "eslint-plugin-react-native": "^4.0.0",
     "eslint-plugin-react-native-a11y": "^3.3.0"
   },

--- a/packages/eslint-config-react-native/package.json
+++ b/packages/eslint-config-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilohealth/eslint-config-react-native",
-  "version": "1.0.0",
+  "version": "1.0.1-beta.1",
   "description": "Kilo.Health ESLint config for React Native",
   "keywords": [
     "eslint",

--- a/packages/eslint-config-react/CHANGELOG.md
+++ b/packages/eslint-config-react/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [@kilohealth/eslint-config-react-v1.0.1-beta.1](https://github.com/kilohealth/eslint-config/compare/@kilohealth/eslint-config-react-v1.0.0...@kilohealth/eslint-config-react-v1.0.1-beta.1) (2023-01-25)
+
+
+### Bug Fixes
+
+* depend on stable versions of packages ([b3b0a5e](https://github.com/kilohealth/eslint-config/commit/b3b0a5ef732ca06769660ff92cefcea57d15040a))
+
 ## @kilohealth/eslint-config-react-v1.0.0 (2023-01-25)
 
 

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilohealth/eslint-config-react",
-  "version": "1.0.0",
+  "version": "1.0.1-beta.1",
   "description": "Kilo.Health ESLint config for React",
   "keywords": [
     "eslint",

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -13,7 +13,7 @@
   "author": "Kilo.Health",
   "main": "./index.js",
   "dependencies": {
-    "@kilohealth/eslint-config-node": "^1.0.0-beta.1"
+    "@kilohealth/eslint-config-node": "^1.0.0"
   },
   "peerDependencies": {
     "eslint": "^8.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -459,14 +459,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@kilohealth/eslint-config-next@workspace:packages/eslint-config-next"
   dependencies:
-    "@kilohealth/eslint-config-react": ^1.0.0-beta.1
-    "@next/eslint-plugin-next": ^13.1.4
+    "@kilohealth/eslint-config-react": ^1.0.0
+    "@next/eslint-plugin-next": ^13.1.5
   peerDependencies:
     eslint: ^8.3.0
   languageName: unknown
   linkType: soft
 
-"@kilohealth/eslint-config-node@^1.0.0-beta.1, @kilohealth/eslint-config-node@workspace:packages/eslint-config-node":
+"@kilohealth/eslint-config-node@^1.0.0, @kilohealth/eslint-config-node@workspace:packages/eslint-config-node":
   version: 0.0.0-use.local
   resolution: "@kilohealth/eslint-config-node@workspace:packages/eslint-config-node"
   dependencies:
@@ -481,7 +481,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@kilohealth/eslint-config-react-native@workspace:packages/eslint-config-react-native"
   dependencies:
-    "@kilohealth/eslint-config-react": ^1.0.0-beta.1
+    "@kilohealth/eslint-config-react": ^1.0.0
     eslint-plugin-react-native: ^4.0.0
     eslint-plugin-react-native-a11y: ^3.3.0
   peerDependencies:
@@ -489,11 +489,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kilohealth/eslint-config-react@^1.0.0-beta.1, @kilohealth/eslint-config-react@workspace:packages/eslint-config-react":
+"@kilohealth/eslint-config-react@^1.0.0, @kilohealth/eslint-config-react@workspace:packages/eslint-config-react":
   version: 0.0.0-use.local
   resolution: "@kilohealth/eslint-config-react@workspace:packages/eslint-config-react"
   dependencies:
-    "@kilohealth/eslint-config-node": ^1.0.0-beta.1
+    "@kilohealth/eslint-config-node": ^1.0.0
   peerDependencies:
     eslint: ^8.3.0
   languageName: unknown
@@ -506,6 +506,25 @@ __metadata:
     eslint-plugin-redux-saga: ^1.3.2
   peerDependencies:
     eslint: ^8.3.0
+  languageName: unknown
+  linkType: soft
+
+"@kilohealth/eslint-config@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "@kilohealth/eslint-config@workspace:."
+  dependencies:
+    "@commitlint/cli": ^17.4.2
+    "@commitlint/config-conventional": ^17.4.2
+    "@semantic-release/changelog": ^6.0.2
+    "@semantic-release/git": ^10.0.1
+    husky: ^8.0.3
+    lerna: ^6.4.1
+    lint-staged: ^13.1.0
+    prettier: ^2.8.3
+    semantic-release: ^19.0.5
+    semantic-release-monorepo: ^7.0.5
+    semantic-release-slack-bot: ^3.5.3
+    sort-package-json: ^2.2.0
   languageName: unknown
   linkType: soft
 
@@ -1314,7 +1333,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/eslint-plugin-next@npm:^13.1.4":
+"@next/eslint-plugin-next@npm:^13.1.5":
   version: 13.1.5
   resolution: "@next/eslint-plugin-next@npm:13.1.5"
   dependencies:
@@ -5986,25 +6005,6 @@ __metadata:
   checksum: 5527fb6d28a446185250fba501ad857370c049bac7aa5a34c9ec82a45e1380af1a96137be7df2f87252d9f75ef67be41d4c0267d481ed0235b2ceb3ee1f5f75d
   languageName: node
   linkType: hard
-
-"kilohealth@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "kilohealth@workspace:."
-  dependencies:
-    "@commitlint/cli": ^17.4.2
-    "@commitlint/config-conventional": ^17.4.2
-    "@semantic-release/changelog": ^6.0.2
-    "@semantic-release/git": ^10.0.1
-    husky: ^8.0.3
-    lerna: ^6.4.1
-    lint-staged: ^13.1.0
-    prettier: ^2.8.3
-    semantic-release: ^19.0.5
-    semantic-release-monorepo: ^7.0.5
-    semantic-release-slack-bot: ^3.5.3
-    sort-package-json: ^2.2.0
-  languageName: unknown
-  linkType: soft
 
 "kind-of@npm:^6.0.2, kind-of@npm:^6.0.3":
   version: 6.0.3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Depend on stable versions of packages:

- @kilohealth/eslint-config-react 1.0.0-beta.1 -> 1.0.0
- @kilohealth/eslint-config-node 1.0.0-beta.1 -> 1.0.0

Minor update of @next/eslint-plugin-next 13.1.4 -> 13.1.5

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->
<!--- Add screenshots (if appropriate) -->

### Checklist

- This is a breaking change:
  - [ ] Yes
  - [x] No
- Will this release a new version:
  - [x] Yes
  - [ ] No
