### PR TITLE
fix: push general yarn.lock file on release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -37,7 +37,7 @@
     [
       "@semantic-release/git",
       {
-        "assets": [ "CHANGELOG.md", "package.json", "yarn.lock" ]
+        "assets": [ "CHANGELOG.md", "package.json", "yarn.lock", "../../yarn.lock" ]
       }
     ],
     [

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,7 +466,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kilohealth/eslint-config-node@^1.0.0, @kilohealth/eslint-config-node@workspace:packages/eslint-config-node":
+"@kilohealth/eslint-config-node@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@kilohealth/eslint-config-node@npm:1.0.0"
+  dependencies:
+    "@shopify/eslint-plugin": ^42.0.3
+    eslint-restricted-globals: ^0.2.0
+  peerDependencies:
+    eslint: ^8.3.0
+  checksum: 57051c9bb41139eb447f7d415bf451e32e49604631687b56559252ed6f4d6a2751ed6468407fdf536b495aef937f762d9a06527934c4bebb46afeb1c46ecc014
+  languageName: node
+  linkType: hard
+
+"@kilohealth/eslint-config-node@workspace:packages/eslint-config-node":
   version: 0.0.0-use.local
   resolution: "@kilohealth/eslint-config-node@workspace:packages/eslint-config-node"
   dependencies:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- Regenerate yarn.lock file
- Push general yarn.lock file on release

<!--- Describe your changes in detail -->

## Motivation and Context

Developer is forced to regenerate yarn.lock locally after each release because general yarn.lock file is not pushed into the repo after release. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->
<!--- Add screenshots (if appropriate) -->

### Checklist

- This is a breaking change:
  - [ ] Yes
  - [x] No
- Will this release a new version:
  - [ ] Yes
  - [x] No
