### PR TITLE
fix: remove jsx-a11y/accessible-emoji in react-native

### DIFF
--- a/packages/eslint-config-react-native/index.js
+++ b/packages/eslint-config-react-native/index.js
@@ -20,6 +20,7 @@ module.exports = {
       { ignoreClassNames: false, ignoreStyleProperties: false },
     ],
     'react-native/split-platform-components': OFF,
+    'jsx-a11y/accessible-emoji': OFF,
   },
   overrides: [
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In react native we do not have Span tag, so this rule does not apply
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->
<!--- Add screenshots (if appropriate) -->

### Checklist

- This is a breaking change:
  - [ ] Yes
  - [x] No
- Will this release a new version:
  - [x] Yes
  - [ ] No
