### PR TITLE
fix: ignore var names with underscore prefix

### DIFF
--- a/packages/eslint-config-node/index.js
+++ b/packages/eslint-config-node/index.js
@@ -25,7 +25,12 @@ module.exports = {
     'eol-last': ERROR,
     'no-unused-vars': [
       ERROR,
-      { vars: 'all', args: 'after-used', ignoreRestSiblings: false },
+      {
+        args: 'after-used',
+        argsIgnorePattern: '^_',
+        ignoreRestSiblings: false,
+        vars: 'all',
+      },
     ],
     'func-style': [ERROR, 'declaration', { allowArrowFunctions: true }],
     'no-restricted-globals': [ERROR].concat(restrictedGlobals),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ignores unused vars which have `_` prefix.
<!--- Describe your changes in detail -->

## Motivation and Context
In redux-toolkit, we use action parameter to define action type. Therefore it used to define type and isn't used anywhere.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Checklist

- This is a breaking change:
  - [ ] Yes
  - [x] No
- Will this release a new version:
  - [x] Yes
  - [ ] No
