### PR TITLE
fix: do not restrict jest matchers / do not add padding lines in switch

### DIFF
--- a/packages/eslint-config-node/index.js
+++ b/packages/eslint-config-node/index.js
@@ -88,6 +88,8 @@ module.exports = {
       { blankLine: 'always', prev: 'block', next: '*' },
       { blankLine: 'always', prev: '*', next: 'block-like' },
       { blankLine: 'always', prev: 'block-like', next: '*' },
+      { blankLine: 'never', prev: 'case', next: ['case', 'default'] },
+      { blankLine: 'never', prev: 'switch', next: ['case', 'default'] },
     ],
     'sort-imports': [
       ERROR,

--- a/packages/eslint-config-node/index.js
+++ b/packages/eslint-config-node/index.js
@@ -157,6 +157,7 @@ module.exports = {
       rules: {
         '@shopify/jest/no-snapshots': OFF,
         '@shopify/strict-component-boundaries': OFF,
+        'jest/no-restricted-matchers': OFF,
       },
     },
   ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Do not restrict jest matchers
- Do not add padding lines in switch statement

## Motivation and Context

- Using await instead of Jest's resolves is arguably less dependent on jest, if the promise rejects it will be treated as a general error, resulting in less predictable behaviour and output from jest.
- Padding lines in switch statement make it hard to read

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->
<!--- Add screenshots (if appropriate) -->

### Checklist

- This is a breaking change:
  - [ ] Yes
  - [x] No
- Will this release a new version:
  - [x] Yes
  - [ ] No
