### PR TITLE
feat: enforce consistent usage of type imports

### DIFF
--- a/packages/eslint-config-node/index.js
+++ b/packages/eslint-config-node/index.js
@@ -160,7 +160,7 @@ module.exports = {
           },
         ],
         '@typescript-eslint/no-explicit-any': WARNING,
-        '@typescript-eslint/consistent-type-imports': ERROR,
+        '@typescript-eslint/consistent-type-imports': WARNING,
         '@shopify/typescript/prefer-pascal-case-enums': OFF,
       },
     },

--- a/packages/eslint-config-node/index.js
+++ b/packages/eslint-config-node/index.js
@@ -160,6 +160,7 @@ module.exports = {
           },
         ],
         '@typescript-eslint/no-explicit-any': WARNING,
+        '@typescript-eslint/consistent-type-imports': ERROR,
         '@shopify/typescript/prefer-pascal-case-enums': OFF,
       },
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Enforce consistent usage of type imports.

## Motivation and Context

TypeScript allows specifying a type keyword on imports to indicate that the export exists only in the type system, not at runtime. This allows transpilers to drop imports without knowing the types of the dependencies.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->
<!--- Add screenshots (if appropriate) -->

### Checklist

- This is a breaking change:
  - [ ] Yes
  - [x] No
- Will this release a new version:
  - [x] Yes
  - [ ] No
